### PR TITLE
feat: Add Certificates section and profile photo placeholder

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ const SkillsSection = dynamic(() => import('@/components/SkillsSection').then(mo
 const ExperienceSection = dynamic(() => import('@/components/ExperienceSection').then(mod => mod.ExperienceSection));
 const ProjectsSection = dynamic(() => import('@/components/ProjectsSection').then(mod => mod.ProjectsSection));
 const EducationSection = dynamic(() => import('@/components/EducationSection').then(mod => mod.EducationSection));
+const CertificatesSection = dynamic(() => import('@/components/CertificatesSection').then(mod => mod.CertificatesSection));
 const ContactSection = dynamic(() => import('@/components/ContactSection').then(mod => mod.ContactSection));
 
 export default function Home() {
@@ -20,6 +21,7 @@ export default function Home() {
         <div id="experience"><ExperienceSection /></div>
         <div id="projects"><ProjectsSection /></div>
         <div id="education"><EducationSection /></div>
+        <div id="certificates"><CertificatesSection /></div>
         <div id="contact"><ContactSection /></div>
         {/* Placeholder for other sections */}
         {/* <div className="container mx-auto p-4 my-12">

--- a/src/components/CertificatesSection.tsx
+++ b/src/components/CertificatesSection.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { motion } from "framer-motion";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+const certificatesData = [
+  {
+    name: "Placeholder Certificate Name 1",
+    organization: "Issuing Organization 1",
+    date: "Date Obtained 1",
+    description: "Brief description or details about the certificate."
+  },
+  {
+    name: "Placeholder Certificate Name 2",
+    organization: "Issuing Organization 2",
+    date: "Date Obtained 2",
+    description: "Brief description or details about the certificate."
+  },
+];
+
+export function CertificatesSection() {
+  return (
+    <section id="certificates" className="py-16 md:py-24 bg-background">
+      <div className="container mx-auto max-w-3xl px-4">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, ease: "easeOut" }}
+          viewport={{ once: true, amount: 0.3 }}
+        >
+          <h2 className="text-4xl font-bold text-center mb-12 text-primary">
+            Certificates
+          </h2>
+          <div className="space-y-8">
+            {certificatesData.map((certificate, index) => (
+              <Card key={index} className="overflow-hidden">
+                <CardHeader>
+                  <CardTitle className="text-2xl text-primary/90">{certificate.name}</CardTitle>
+                  <CardDescription className="text-base">
+                    {certificate.organization} - {certificate.date}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-lg text-muted-foreground">
+                    {certificate.description}
+                  </p>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import Image from "next/image";
 import { motion, useScroll, useTransform } from "framer-motion";
 import { ArrowDown } from "lucide-react";
 import { useRef } from "react";
@@ -32,6 +33,14 @@ export function HeroSection() {
   return (
     <section id="home" ref={targetRef} className="relative flex h-screen flex-col items-center justify-center text-center overflow-hidden">
       <ParticlesBackground />
+      <Image
+        src="https://via.placeholder.com/200"
+        alt="Arman Rafiee - Profile Photo"
+        width={200}
+        height={200}
+        className="rounded-full mx-auto mb-4 z-10"
+        priority // Good to add for LCP elements
+      />
       <motion.div
         style={{ y: titleY, opacity: titleOpacity }}
         className="z-10 p-4"

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -12,6 +12,7 @@ const navItems = [
   { name: "Projects", href: "/#projects" },
   { name: "Experience", href: "/#experience" },
   { name: "Education", href: "/#education" },
+  { name: "Certificates", href: "/#certificates" },
   { name: "Contact", href: "/#contact" },
 ];
 


### PR DESCRIPTION
I've added a new `CertificatesSection` to display your professional certifications. This section uses `Card` components for each certificate and includes placeholder content.

The `CertificatesSection` has been integrated into the main page (`page.tsx`) and a navigation link has been added to `Navbar.tsx`.

A placeholder for your personal photo has been added to the `HeroSection.tsx` using `next/image`. The image is styled to be circular and is positioned above the name and title. You should replace the placeholder URL with your actual photo.